### PR TITLE
Add weekday support and update prompts

### DIFF
--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
+os.environ.setdefault('YANDEX_IAM_TOKEN', 'x')
+os.environ.setdefault('YANDEX_FOLDER_ID', 'x')
+
+from utils import next_weekday, normalize_date
+
+class FixedDatetime(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2025, 7, 28)
+
+def test_next_weekday(monkeypatch):
+    monkeypatch.setattr('utils.datetime', FixedDatetime)
+    assert next_weekday('пт') == '2025-08-01'
+    assert next_weekday('вс') == '2025-08-03'
+
+def test_normalize_date_weekday(monkeypatch):
+    monkeypatch.setattr('utils.datetime', FixedDatetime)
+    assert normalize_date('в пятницу') == '2025-08-01'
+

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,23 @@
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
+os.environ.setdefault('YANDEX_IAM_TOKEN', 'x')
+os.environ.setdefault('YANDEX_FOLDER_ID', 'x')
+
+from parser import parse_transport
+
+def test_plane():
+    assert parse_transport('хочу полететь в Москву') == 'plane'
+
+def test_bus():
+    assert parse_transport('доедем на басе в Казань') == 'bus'
+
+def test_train():
+    assert parse_transport('билеты на поезд до Сочи') == 'train'
+
+def test_default():
+    assert parse_transport('нужно в Нижний Новгород') == 'train'

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,45 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
+import re
+
 import dateparser
+
+# Словарь соответствий дней недели
+DAYS_MAP = {
+    "понедельник": 0, "пн": 0, "пон": 0,
+    "вторник": 1, "вт": 1, "втр": 1,
+    "среда": 2, "ср": 2,
+    "четверг": 3, "чт": 3, "чет": 3,
+    "пятница": 4, "пт": 4, "пятн": 4,
+    "суббота": 5, "сб": 5, "суб": 5,
+    "воскресенье": 6, "вс": 6, "воскр": 6,
+}
+
+
+def next_weekday(target_word: str) -> str:
+    """Return next date for given weekday word in YYYY-MM-DD."""
+    today = datetime.now()
+    weekday_today = today.weekday()  # 0 = понедельник
+    target = DAYS_MAP.get(target_word.lower())
+    if target is None:
+        return ""
+    days_ahead = (target - weekday_today) % 7
+    if days_ahead == 0:
+        days_ahead = 7
+    date_result = today + timedelta(days=days_ahead)
+    return date_result.strftime("%Y-%m-%d")
 
 
 def normalize_date(text: str) -> Optional[str]:
     """Возвращает дату в формате YYYY-MM-DD или None."""
+    text_lower = text.lower()
+    for word in DAYS_MAP:
+        if re.search(rf"\b{re.escape(word)}\w*", text_lower):
+            date_str = next_weekday(word)
+            if date_str:
+                return date_str
+
     dt = dateparser.parse(text, languages=['ru'])
     if not dt:
         return None
@@ -13,3 +47,4 @@ def normalize_date(text: str) -> Optional[str]:
     if dt.date() < datetime.now().date():
         return None
     return dt.strftime('%Y-%m-%d')
+


### PR DESCRIPTION
## Summary
- update YandexGPT prompts with weekday rule
- map Yandex response fields to existing slot names
- implement `next_weekday` and extend `normalize_date`
- add tests for weekday parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a334875b0832994c50f8dbc253a9a