### PR TITLE
Handle unknown transport and ask for clarification

### DIFF
--- a/main.py
+++ b/main.py
@@ -134,7 +134,7 @@ async def handle_slots(message: Message, state: Optional[Dict[str, Optional[str]
     session_data = {uid: state}
     slots, changed = await update_slots(uid, text, session_data, question)
 
-    slots = await complete_slots(slots)
+    slots, transport_question = await complete_slots(slots)
 
     state = session_data[uid] = slots
     try:
@@ -159,7 +159,10 @@ async def handle_slots(message: Message, state: Optional[Dict[str, Optional[str]
         return
 
     if missing:
-        question_text = await generate_question(missing[0], DEFAULT_QUESTIONS[missing[0]])
+        if transport_question and 'transport' in missing:
+            question_text = transport_question
+        else:
+            question_text = await generate_question(missing[0], DEFAULT_QUESTIONS[missing[0]])
         state['last_question'] = question_text
         try:
             await set_user_state(uid, state)
@@ -304,7 +307,7 @@ async def handle_message(message: Message):
             state.pop('confirm', None)
             session_data = {uid: state}
             slots, changed = await update_slots(uid, message.text, session_data)
-            slots = await complete_slots(slots)
+            slots, transport_question = await complete_slots(slots)
             state = session_data[uid]
             changed_msg = ''
             if changed:
@@ -316,7 +319,10 @@ async def handle_message(message: Message):
 
             missing = get_missing_slots(slots)
             if missing:
-                question_text = await generate_question(missing[0], DEFAULT_QUESTIONS[missing[0]])
+                if transport_question and 'transport' in missing:
+                    question_text = transport_question
+                else:
+                    question_text = await generate_question(missing[0], DEFAULT_QUESTIONS[missing[0]])
                 state['last_question'] = question_text
                 try:
                     await set_user_state(uid, state)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -2,29 +2,72 @@
 import os
 import sys
 
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+from yarl import URL
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
 os.environ.setdefault('YANDEX_IAM_TOKEN', 'x')
 os.environ.setdefault('YANDEX_FOLDER_ID', 'x')
 
+import parser
 from parser import parse_transport
 from utils import display_transport
+
 
 def test_plane():
     assert parse_transport('хочу полететь в Москву') == 'plane'
 
+
 def test_bus():
     assert parse_transport('доедем на басе в Казань') == 'bus'
+
 
 def test_train():
     assert parse_transport('билеты на поезд до Сочи') == 'train'
 
+
 def test_default():
-    assert parse_transport('нужно в Нижний Новгород') == 'train'
+    assert parse_transport('нужно в Нижний Новгород') is None
 
 
 def test_display_transport():
     assert display_transport('plane') == 'самолет'
     assert display_transport('bus') == 'автобус'
     assert display_transport('train') == 'поезд'
+    assert display_transport(None) == 'не указан'
+
+
+@pytest.mark.asyncio
+async def test_question_on_missing_transport():
+    slots = {
+        'from': 'Москва',
+        'to': 'Казань',
+        'date': '2025-08-05',
+        'transport': None,
+    }
+    with aioresponses() as m:
+        m.post(parser.API_URL, exception=aiohttp.ClientError, repeat=True)
+        updated, question = await parser.complete_slots(slots)
+        assert ('POST', URL(parser.API_URL)) in m.requests
+    assert updated['transport'] is None
+    assert question == parser.TRANSPORT_QUESTION_FALLBACK
+
+
+@pytest.mark.asyncio
+async def test_transport_preserved():
+    slots = {
+        'from': 'Москва',
+        'to': 'Казань',
+        'date': '2025-08-05',
+        'transport': 'bus',
+    }
+    with aioresponses() as m:
+        m.post(parser.API_URL, exception=aiohttp.ClientError, repeat=True)
+        updated, question = await parser.complete_slots(slots)
+        assert ('POST', URL(parser.API_URL)) in m.requests
+    assert updated['transport'] == 'bus'
+    assert question is None

--- a/utils.py
+++ b/utils.py
@@ -60,6 +60,6 @@ TRANSPORT_RU = {
 def display_transport(value: Optional[str]) -> str:
     """Return Russian name for a transport code."""
     if not value:
-        return ''
+        return 'не указан'
     return TRANSPORT_RU.get(value.lower(), value)
 


### PR DESCRIPTION
## Summary
- Return `None` when transport type can't be parsed
- Ask YandexGPT to clarify transport when slot remains empty
- Display `не указан` for missing transport
- Add tests for transport clarification and preservation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bb91a08e88329898159d38bbbfdba