### PR TITLE
Add manager moderation commands and trip status

### DIFF
--- a/manager_bot.py
+++ b/manager_bot.py
@@ -1,23 +1,82 @@
 import asyncio
 from aiogram import Bot, Dispatcher
+from aiogram.enums import ParseMode
 from aiogram.filters import Command
 from aiogram.types import Message
 
-from config import MANAGER_BOT_TOKEN
+from config import MANAGER_BOT_TOKEN, TELEGRAM_BOT_TOKEN
+import storage
 
 if not MANAGER_BOT_TOKEN:
     raise RuntimeError("MANAGER_BOT_TOKEN is not set")
 
 bot = Bot(token=MANAGER_BOT_TOKEN)
+user_bot = Bot(token=TELEGRAM_BOT_TOKEN)
 
 dp = Dispatcher()
+
 
 @dp.message(Command('start'))
 async def cmd_start(message: Message):
     await message.answer('Здесь будут появляться новые заявки на бронирование.')
 
+
+def _parse_id(arg: str) -> int | None:
+    try:
+        return int(arg)
+    except (TypeError, ValueError):
+        return None
+
+
+@dp.message(Command('approve'))
+async def cmd_approve(message: Message):
+    parts = message.text.split()
+    trip_id = _parse_id(parts[1]) if len(parts) > 1 else None
+    if not trip_id:
+        await message.answer('Некорректный ID заявки')
+        return
+    trip = storage.get_trip(trip_id)
+    if not trip:
+        await message.answer('Заявка не найдена')
+        return
+    storage.update_trip_status(trip_id, 'approved')
+    await message.answer(f"Заявка {trip_id} одобрена")
+    await user_bot.send_message(trip['user_id'], f"Вашу заявку №{trip_id} одобрили")
+
+
+@dp.message(Command('reject'))
+async def cmd_reject(message: Message):
+    parts = message.text.split()
+    trip_id = _parse_id(parts[1]) if len(parts) > 1 else None
+    if not trip_id:
+        await message.answer('Некорректный ID заявки')
+        return
+    trip = storage.get_trip(trip_id)
+    if not trip:
+        await message.answer('Заявка не найдена')
+        return
+    storage.update_trip_status(trip_id, 'rejected')
+    await message.answer(f"Заявка {trip_id} отклонена")
+    await user_bot.send_message(trip['user_id'], f"Вашу заявку №{trip_id} отклонили")
+
+
+@dp.message(Command('list'))
+async def cmd_list(message: Message):
+    parts = message.text.split()
+    status = parts[1] if len(parts) > 1 else 'pending'
+    trips = storage.get_trips_by_status(status)
+    if not trips:
+        await message.answer('Заявки не найдены')
+        return
+    lines = [
+        f"<b>{t['id']}</b>: {t['origin']} → {t['destination']} {t['date']} ({t['status']})" for t in trips
+    ]
+    await message.answer('\n'.join(lines), parse_mode=ParseMode.HTML)
+
+
 async def main():
     await dp.start_polling(bot)
+
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/tests/test_manager_bot.py
+++ b/tests/test_manager_bot.py
@@ -1,0 +1,82 @@
+import os
+import importlib
+import tempfile
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.types import Message, Chat, User
+import sys
+
+os.environ['TELEGRAM_BOT_TOKEN'] = '123:abc'
+os.environ['MANAGER_BOT_TOKEN'] = '456:def'
+
+
+tmp = tempfile.NamedTemporaryFile(delete=False)
+os.environ['TRIPS_DB'] = tmp.name
+tmp.close()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import config
+importlib.reload(config)
+import storage
+import manager_bot
+importlib.reload(storage)
+importlib.reload(manager_bot)
+
+storage.init_db()
+
+
+def _make_message(text: str) -> Message:
+    return Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=Chat(id=1, type='private'),
+        from_user=User(id=123, is_bot=False, first_name='Test'),
+        text=text,
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_command():
+    storage.init_db()
+    trip_id = storage.save_trip({'user_id': 123, 'origin': 'A', 'destination': 'B', 'date': '2025-01-01', 'transport': 'bus'})
+    msg = _make_message(f'/approve {trip_id}')
+    object.__setattr__(msg, 'answer', AsyncMock())
+    manager_bot.user_bot.send_message = AsyncMock()
+
+    await manager_bot.cmd_approve(msg)
+
+    trip = storage.get_trip(trip_id)
+    assert trip['status'] == 'approved'
+    manager_bot.user_bot.send_message.assert_called_with(123, f'Вашу заявку №{trip_id} одобрили')
+
+
+@pytest.mark.asyncio
+async def test_approve_invalid_id():
+    storage.init_db()
+    msg = _make_message('/approve 999')
+    object.__setattr__(msg, 'answer', AsyncMock())
+    manager_bot.user_bot.send_message = AsyncMock()
+
+    await manager_bot.cmd_approve(msg)
+
+    msg.answer.assert_called()
+    manager_bot.user_bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_command():
+    storage.init_db()
+    storage.save_trip({'user_id': 1, 'origin': 'C', 'destination': 'D', 'date': '2025-01-01', 'transport': 'bus'})
+    storage.save_trip({'user_id': 1, 'origin': 'E', 'destination': 'F', 'date': '2025-01-02', 'transport': 'bus', 'status': 'approved'})
+    msg = _make_message('/list')
+    object.__setattr__(msg, 'answer', AsyncMock())
+
+    await manager_bot.cmd_list(msg)
+
+    msg.answer.assert_called()
+    text = msg.answer.call_args[0][0]
+    assert 'pending' in text
+
+    os.unlink(os.environ['TRIPS_DB'])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,8 +1,9 @@
 import os
 import importlib
 import tempfile
+import sys
 
-os.environ['TELEGRAM_BOT_TOKEN'] = os.environ.get('TELEGRAM_BOT_TOKEN', 'x')
+os.environ['TELEGRAM_BOT_TOKEN'] = os.environ.get('TELEGRAM_BOT_TOKEN', '123:abc')
 os.environ['YANDEX_IAM_TOKEN'] = os.environ.get('YANDEX_IAM_TOKEN', 'x')
 os.environ['YANDEX_FOLDER_ID'] = os.environ.get('YANDEX_FOLDER_ID', 'x')
 
@@ -10,6 +11,7 @@ tmp = tempfile.NamedTemporaryFile(delete=False)
 os.environ['TRIPS_DB'] = tmp.name
 tmp.close()
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import storage
 importlib.reload(storage)
 
@@ -17,6 +19,7 @@ storage.init_db()
 
 
 def test_save_and_get_cancel():
+    storage.init_db()
     trip_id = storage.save_trip({
         'user_id': 1,
         'origin': 'A',
@@ -26,9 +29,9 @@ def test_save_and_get_cancel():
     })
     trips = storage.get_last_trips(1)
     assert trips[0]['id'] == trip_id
-    assert trips[0]['status'] == 'active'
+    assert trips[0]['status'] == 'pending'
     assert storage.cancel_trip(trip_id) is True
     trips = storage.get_last_trips(1)
-    assert trips[0]['status'] == 'cancelled'
+    assert trips[0]['status'] == 'rejected'
     os.unlink(os.environ['TRIPS_DB'])
 


### PR DESCRIPTION
## Summary
- add status field with migration and helpers for trips
- allow manager bot to approve/reject trips and list by status
- cover manager workflow with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689232fbaaa48329b9376af78f1f3276