### PR TITLE
Enhance booking flow with extra details and payment stages

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ YANDEX_IAM_TOKEN = os.getenv('YANDEX_IAM_TOKEN')
 YANDEX_FOLDER_ID = os.getenv('YANDEX_FOLDER_ID')
 MANAGER_BOT_TOKEN = os.getenv('MANAGER_BOT_TOKEN')
 MANAGER_CHAT_ID = os.getenv('MANAGER_CHAT_ID')
+PAYMENT_DETAILS = os.getenv('PAYMENT_DETAILS', 'реквизиты не указаны')
 
 if not TELEGRAM_BOT_TOKEN:
     raise RuntimeError('TELEGRAM_BOT_TOKEN is not set')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiohttp
 aioresponses
 pytest-asyncio
 asyncpg
+fpdf2

--- a/tests/test_manager_bot.py
+++ b/tests/test_manager_bot.py
@@ -11,7 +11,6 @@ import sys
 os.environ['TELEGRAM_BOT_TOKEN'] = '123:abc'
 os.environ['MANAGER_BOT_TOKEN'] = '456:def'
 
-
 tmp = tempfile.NamedTemporaryFile(delete=False)
 os.environ['TRIPS_DB'] = tmp.name
 tmp.close()
@@ -36,30 +35,44 @@ def _make_message(text: str) -> Message:
         text=text,
     )
 
-
 @pytest.mark.asyncio
-async def test_approve_command():
+async def test_accept_price_confirm_commands():
     storage.init_db()
     trip_id = storage.save_trip({'user_id': 123, 'origin': 'A', 'destination': 'B', 'date': '2025-01-01', 'transport': 'bus'})
-    msg = _make_message(f'/approve {trip_id}')
-    object.__setattr__(msg, 'answer', AsyncMock())
+
+    msg_accept = _make_message(f'/accept {trip_id}')
+    object.__setattr__(msg_accept, 'answer', AsyncMock())
     manager_bot.user_bot.send_message = AsyncMock()
-
-    await manager_bot.cmd_approve(msg)
-
+    await manager_bot.cmd_accept(msg_accept)
     trip = storage.get_trip(trip_id)
-    assert trip['status'] == 'approved'
-    manager_bot.user_bot.send_message.assert_called_with(123, f'Вашу заявку №{trip_id} одобрили')
+    assert trip['status'] == 'accepted'
+    manager_bot.user_bot.send_message.assert_called_with(123, f'Вашу заявку №{trip_id} приняли в работу')
+
+    msg_price = _make_message(f'/price {trip_id} 1000')
+    object.__setattr__(msg_price, 'answer', AsyncMock())
+    manager_bot.user_bot.send_message = AsyncMock()
+    await manager_bot.cmd_price(msg_price)
+    trip = storage.get_trip(trip_id)
+    assert trip['status'] == 'awaiting_payment'
+    manager_bot.user_bot.send_message.assert_called()
+
+    msg_confirm = _make_message(f'/confirm {trip_id}')
+    object.__setattr__(msg_confirm, 'answer', AsyncMock())
+    manager_bot.user_bot.send_document = AsyncMock()
+    await manager_bot.cmd_confirm(msg_confirm)
+    trip = storage.get_trip(trip_id)
+    assert trip['status'] == 'confirmed'
+    manager_bot.user_bot.send_document.assert_called()
 
 
 @pytest.mark.asyncio
-async def test_approve_invalid_id():
+async def test_accept_invalid_id():
     storage.init_db()
-    msg = _make_message('/approve 999')
+    msg = _make_message('/accept 999')
     object.__setattr__(msg, 'answer', AsyncMock())
     manager_bot.user_bot.send_message = AsyncMock()
 
-    await manager_bot.cmd_approve(msg)
+    await manager_bot.cmd_accept(msg)
 
     msg.answer.assert_called()
     manager_bot.user_bot.send_message.assert_not_called()
@@ -69,7 +82,7 @@ async def test_approve_invalid_id():
 async def test_list_command():
     storage.init_db()
     storage.save_trip({'user_id': 1, 'origin': 'C', 'destination': 'D', 'date': '2025-01-01', 'transport': 'bus'})
-    storage.save_trip({'user_id': 1, 'origin': 'E', 'destination': 'F', 'date': '2025-01-02', 'transport': 'bus', 'status': 'approved'})
+    storage.save_trip({'user_id': 1, 'origin': 'E', 'destination': 'F', 'date': '2025-01-02', 'transport': 'bus', 'status': 'accepted'})
     msg = _make_message('/list')
     object.__setattr__(msg, 'answer', AsyncMock())
 


### PR DESCRIPTION
## Summary
- ask users for desired time, baggage needs, and passenger count before sending request to manager
- add manager commands for accepting orders, sending price, and confirming payment with a generated ticket
- expose payment details config and add PDF generation dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68923979f960832986e47beaf05ec714