### PR TITLE
Parse trip time via Yandex GPT and show booking ID to managers

### DIFF
--- a/tests/test_notify_manager.py
+++ b/tests/test_notify_manager.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.types import User
+
+os.environ['TELEGRAM_BOT_TOKEN'] = '123:abc'
+os.environ['MANAGER_BOT_TOKEN'] = '456:def'
+os.environ['MANAGER_CHAT_ID'] = '789'
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import config
+importlib.reload(config)
+import main
+importlib.reload(main)
+
+@pytest.mark.asyncio
+async def test_notify_manager_includes_id():
+    main.manager_bot.send_message = AsyncMock()
+    user = User(id=1, is_bot=False, first_name='Test', username='tester')
+    slots = {'from': 'A', 'to': 'B', 'date': '2025-01-01', 'transport': 'bus', 'time': '08:00'}
+    await main.notify_manager(42, slots, user)
+    assert main.manager_bot.send_message.called
+    text = main.manager_bot.send_message.call_args[0][1]
+    assert '42' in text
+    assert '08:00' in text

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+import pytest
+from aioresponses import aioresponses
+
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'x')
+os.environ.setdefault('YANDEX_IAM_TOKEN', 'x')
+os.environ.setdefault('YANDEX_FOLDER_ID', 'x')
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import normalize_time
+from parser import API_URL
+
+
+@pytest.mark.asyncio
+async def test_normalize_time_digits():
+    with aioresponses() as m:
+        m.post(API_URL, payload={'result': {'alternatives': [{'message': {'text': '09:30'}}]}})
+        assert await normalize_time('9:30') == '09:30'
+
+
+@pytest.mark.asyncio
+async def test_normalize_time_text():
+    with aioresponses() as m:
+        m.post(API_URL, payload={'result': {'alternatives': [{'message': {'text': '20:00'}}]}})
+        assert await normalize_time('в восемь вечера') == '20:00'


### PR DESCRIPTION
## Summary
- Normalize textual or numeric time inputs through Yandex GPT for 24-hour format
- Include booking ID in manager notifications and parse time for extra questions
- Add tests for GPT-based time normalization and manager notification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899b5590a2c8329871585ca93040f6c