### PR TITLE
Add heuristic slot extraction to reduce LLM calls

### DIFF
--- a/src/bookingassistant/manager_bot.py
+++ b/src/bookingassistant/manager_bot.py
@@ -97,15 +97,15 @@ def _generate_ticket_pdf(trip: dict) -> bytes:
     pdf = FPDF()
     pdf.add_page()
     pdf.set_font("Helvetica", size=14)
-    pdf.cell(0, 10, text=PDF_TICKET_TITLE, new_x="LMARGIN", new_y="NEXT", align="C")
+    pdf.cell(0, 10, PDF_TICKET_TITLE, align="C", ln=1)
     pdf.ln(10)
     pdf.set_font("Helvetica", size=12)
     pdf.multi_cell(
         0,
         10,
-        text=f"Route: {trip['origin']} -> {trip['destination']}\nDate: {trip['date']}\nTransport: {trip['transport']}",
+        f"Route: {trip['origin']} -> {trip['destination']}\nDate: {trip['date']}\nTransport: {trip['transport']}",
     )
-    return bytes(pdf.output(dest="S"))
+    return pdf.output(dest="S").encode("latin1")
 
 
 @dp.message(Command("confirm"))

--- a/src/bookingassistant/slot_editor.py
+++ b/src/bookingassistant/slot_editor.py
@@ -12,6 +12,7 @@ async def update_slots(
     message: str,
     session_data: Dict[int, Dict[str, Optional[str]]],
     question: Optional[str] = None,
+    pre_slots: Optional[Dict[str, Optional[str]]] = None,
 ) -> tuple[Dict[str, Optional[str]], Dict[str, str]]:
     """Update saved slots for a user based on correction message.
 
@@ -49,7 +50,10 @@ async def update_slots(
 
     logger.info("Editing slots for %s: %s", user_id, message)
 
-    parsed = await parse_slots(message, question)
+    if pre_slots is not None:
+        parsed = dict(pre_slots)
+    else:
+        parsed = await parse_slots(message, question)
     user_date = normalize_date(message)
     if user_date:
         parsed["date"] = user_date

--- a/src/tests/test_commands.py
+++ b/src/tests/test_commands.py
@@ -11,6 +11,8 @@ from aioresponses import aioresponses
 from yarl import URL
 
 import bookingassistant.parser as parser
+import bookingassistant.slot_editor as slot_editor
+from bookingassistant.utils import pre_extract_slots
 
 importlib.reload(parser)
 
@@ -36,3 +38,27 @@ async def test_cancel_command():
         data["destination"].lower() == "москву"
         or data["destination"].lower() == "москва"
     )
+
+
+@pytest.mark.asyncio
+async def test_no_llm_called(monkeypatch):
+    called = False
+
+    async def fake_generate_text(*args, **kwargs):
+        nonlocal called
+        called = True
+        return ""
+
+    monkeypatch.setattr(parser, "generate_text", fake_generate_text)
+
+    async def fake_parse_slots(*args, **kwargs):
+        raise AssertionError("parse_slots should not be called")
+
+    monkeypatch.setattr(slot_editor, "parse_slots", fake_parse_slots)
+
+    session_data = {}
+    text = "Я завтра в Минск на автобусе из Гродно"
+    pre = pre_extract_slots(text)
+    await slot_editor.update_slots(1, text, session_data, pre_slots=pre)
+
+    assert called is False

--- a/src/tests/test_pre_extract_slots.py
+++ b/src/tests/test_pre_extract_slots.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+from datetime import datetime, timedelta
+
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "x")
+os.environ.setdefault("YANDEX_IAM_TOKEN", "x")
+os.environ.setdefault("YANDEX_FOLDER_ID", "x")
+
+from bookingassistant.utils import pre_extract_slots
+
+
+def test_pre_extract_slots_basic():
+    text = "Я завтра в Минск на автобусе из Гродно"
+    slots = pre_extract_slots(text)
+    assert slots["from"].lower() == "гродно"
+    assert slots["to"].lower() == "минск"
+    assert slots["transport"] == "bus"
+    expected = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    assert slots["date"] == expected


### PR DESCRIPTION
## Summary
- add `pre_extract_slots` heuristic parser for transport, cities and dates
- skip LLM slot parsing when heuristics fill enough slots
- adjust PDF ticket generation for current FPDF API
- cover heuristics with tests and ensure no LLM call for basic requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a591a725083298ce7af4c127d693d