### PR TITLE
Validate LLM slot JSON with Pydantic and retry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "SQLAlchemy>=2",
     "fpdf2",
     "certifi",
+    "pydantic",
 ]
 
 [tool.pytest.ini_options]

--- a/src/bookingassistant/manager_bot.py
+++ b/src/bookingassistant/manager_bot.py
@@ -105,7 +105,8 @@ def _generate_ticket_pdf(trip: dict) -> bytes:
         10,
         f"Route: {trip['origin']} -> {trip['destination']}\nDate: {trip['date']}\nTransport: {trip['transport']}",
     )
-    return pdf.output(dest="S").encode("latin1")
+    data = pdf.output(dest="S")
+    return data if isinstance(data, (bytes, bytearray)) else data.encode("latin1")
 
 
 @dp.message(Command("confirm"))

--- a/src/bookingassistant/models.py
+++ b/src/bookingassistant/models.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field, ConfigDict
+from typing import Optional, Literal
+
+Transport = Literal['bus', 'train', 'plane']
+
+
+class SlotsModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, validate_assignment=False)
+
+    from_: Optional[str] = Field(None, alias='from')
+    to: Optional[str] = None
+    date: Optional[str] = None  # ISO YYYY-MM-DD
+    transport: Optional[Transport] = None
+    confidence: Optional[float] = 1.0

--- a/src/tests/test_parser_pydantic.py
+++ b/src/tests/test_parser_pydantic.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+from aioresponses import aioresponses
+from yarl import URL
+
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "x")
+os.environ.setdefault("YANDEX_IAM_TOKEN", "x")
+os.environ.setdefault("YANDEX_FOLDER_ID", "x")
+
+from bookingassistant.parser import parse_slots
+from bookingassistant.gpt import API_URL
+from bookingassistant.models import SlotsModel
+
+
+@pytest.mark.asyncio
+async def test_parse_slots_retry_success():
+    bad = {"result": {"alternatives": [{"message": {"text": "не json"}}]}}
+    good_text = (
+        "{\"from\": \"A\", \"to\": \"B\", \"date\": \"2024-01-01\", \"transport\": \"bus\", \"confidence\": 0.5}"
+    )
+    good = {"result": {"alternatives": [{"message": {"text": good_text}}]}}
+    with aioresponses() as m:
+        m.post(API_URL, payload=bad)
+        m.post(API_URL, payload=good)
+        result = await parse_slots("text")
+        assert result == {
+            "from": "A",
+            "to": "B",
+            "date": "2024-01-01",
+            "transport": "bus",
+            "confidence": 0.5,
+        }
+        assert len(m.requests[('POST', URL(API_URL))]) == 2
+
+
+@pytest.mark.asyncio
+async def test_parse_slots_retry_default():
+    bad = {"result": {"alternatives": [{"message": {"text": "не json"}}]}}
+    with aioresponses() as m:
+        m.post(API_URL, payload=bad)
+        m.post(API_URL, payload=bad)
+        result = await parse_slots("text")
+        expected = SlotsModel().model_dump(by_alias=True)
+        assert result == expected
+        assert len(m.requests[('POST', URL(API_URL))]) == 2


### PR DESCRIPTION
## Summary
- introduce `SlotsModel` using Pydantic for strict slot schema
- validate LLM responses with retry on invalid JSON and provide safe defaults
- handle PDF bytes generation and add Pydantic dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5d68a9a08329943fbc49017cc67d