### PR TITLE
Add unified startup for both bots and IAM token override

### DIFF
--- a/src/bookingassistant/__init__.py
+++ b/src/bookingassistant/__init__.py
@@ -1,1 +1,24 @@
-"""Booking Assistant package."""
+"""Booking Assistant package.
+
+This module provides a single entry point that launches both the user
+facing bot and the manager bot.  Running ``python -m bookingassistant``
+will start them concurrently so there is no need to run two separate
+scripts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from .main import main as _run_user_bot
+from .manager_bot import main as _run_manager_bot
+
+
+async def run_bots() -> None:
+    """Start both bots concurrently."""
+
+    await asyncio.gather(_run_user_bot(), _run_manager_bot())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    asyncio.run(run_bots())

--- a/src/bookingassistant/iam.py
+++ b/src/bookingassistant/iam.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -80,6 +81,12 @@ class AsyncIamTokenManager:
         )
 
     async def get_token(self) -> str:
+        # Позволяем переопределить IAM-токен через переменную окружения,
+        # чтобы тесты и офлайн-запуски не обращались к сети.
+        override = os.getenv("YANDEX_IAM_TOKEN")
+        if override:
+            return override
+
         # Быстрая проверка без блокировки
         if not self._needs_refresh_unlocked():
             return self._state.token  # type: ignore[return-value]


### PR DESCRIPTION
## Summary
- Start both user and manager bots when executing the package directly
- Allow supplying an IAM token via `YANDEX_IAM_TOKEN` environment variable to skip network requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dddcbf1b88329b8907d2d577f52dc