### PR TITLE
Handle missing Yandex IAM key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ MANAGER_BOT_TOKEN=manager_bot_token
 MANAGER_CHAT_ID=manager_chat_id
 ```
 
+При наличии готового IAM-токена можно обойтись без файла ключа и просто
+указать его через переменную окружения `YANDEX_IAM_TOKEN`.
+
 3. Установите зависимости:
 
 ```bash

--- a/src/bookingassistant/__init__.py
+++ b/src/bookingassistant/__init__.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 import asyncio
 
-from .main import main as _run_user_bot
-from .manager_bot import main as _run_manager_bot
-
-
 async def run_bots() -> None:
     """Start both bots concurrently."""
+
+    # Import lazily so that configuration is not required at import time.
+    from .main import main as _run_user_bot
+    from .manager_bot import main as _run_manager_bot
 
     await asyncio.gather(_run_user_bot(), _run_manager_bot())
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# Provide default environment variables required by bookingassistant.config
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "1234567890:" + "A" * 35)
+os.environ.setdefault("YANDEX_IAM_TOKEN", "x")
+os.environ.setdefault("YANDEX_FOLDER_ID", "x")

--- a/src/tests/test_iam_token_manager.py
+++ b/src/tests/test_iam_token_manager.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+
+from bookingassistant.iam import AsyncIamTokenManager
+
+
+@pytest.mark.asyncio
+async def test_env_token_skips_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("YANDEX_IAM_TOKEN", "token")
+    missing = tmp_path / "missing.json"
+    manager = AsyncIamTokenManager(sa_key_path=str(missing))
+    assert await manager.get_token() == "token"
+
+
+def test_missing_file_without_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("YANDEX_IAM_TOKEN", raising=False)
+    missing = tmp_path / "missing.json"
+    with pytest.raises(RuntimeError):
+        AsyncIamTokenManager(sa_key_path=str(missing))


### PR DESCRIPTION
## Summary
- Skip reading a service account file when `YANDEX_IAM_TOKEN` is provided and report clear errors for missing or invalid key files
- Lazily import bot entrypoints to avoid requiring configuration on package import
- Document `YANDEX_IAM_TOKEN` usage and add tests for token manager behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689de567846c832991882ab2a6d0efdf